### PR TITLE
Add latest angular-material markup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
     "tests"
   ],
   "dependencies": {
-    "angular-material": "~0.4.0"
+    "angular-material": "~0.8.0"
   }
 }

--- a/docs/templates/base.template.html
+++ b/docs/templates/base.template.html
@@ -2,22 +2,25 @@
 <html ng-app="app">
 <head>
   <title>Dgeni Angular</title>
-  <link rel="stylesheet" type="text/css" href="/lib/angular-material/angular-material.css">
-  <script src="/lib/angular/angular.js"></script>
-  <script src="/lib/angular-animate/angular-animate.js"></script>
-  <script src="/lib/angular-aria/angular-aria.js"></script>
-  <script src="/lib/hammerjs/hammer.js"></script>
-  <script src="/lib/angular-material/angular-material.js"></script>
+  <link rel="stylesheet" type="text/css" href="/lib/angular-material/angular-material.min.css">
+  <style>
+    a:link, a:visited { color: #3f51b5; text-decoration: none }
+    a:hover { text-decoration: underline; }
+  </style>
+  <script src="/lib/angular/angular.min.js"></script>
+  <script src="/lib/angular-animate/angular-animate.min.js"></script>
+  <script src="/lib/angular-aria/angular-aria.min.js"></script>
+  <script src="/lib/angular-material/angular-material.min.js"></script>
   <script type="text/javascript">
   angular.module('app', ['ngMaterial', 'ngAnimate', 'ngAria']);
   </script>
 </head>
-<body
-  layout="vertical"
-  style="width: 600px"
-  class="material-whiteframe-z1">
-  <material-content layout-padding>
+<body layout="column">
+  <md-toolbar>
+    <h2 class="md-toolbar-tools">Dgeni Angular</h2>
+  </md-toolbar>
+  <md-content layout-padding>
   {% block body %}{% endblock %}
-  </material-content>
+  </md-content>
 </body>
 </html>

--- a/docs/templates/componentGroup.template.html
+++ b/docs/templates/componentGroup.template.html
@@ -3,11 +3,24 @@
 {% block body %}
 <h2>{$ doc.title $} in {$ doc.module.name $}</h2>
 
-<ul>
 {% for component in doc.children %}
-<li>{$ component | relativeLink(doc) $}
-    {%- if component.description %} - {$ component.description $}{% endif -%}
-</li>
+<section>
+	<md-list>
+	{% for component in doc.children %}
+		<md-item>
+			<md-item-content layout-sm="column" layout-align-sm="space-around start">
+				<div class="md-tile-left" flex="15">
+					{$ component | relativeLink(doc) $}
+				</div>
+				<div class="md-tile-content">
+					{%- if component.description %} {$ component.description $}{% endif -%}
+				</div>
+			</md-item-content>
+			<md-divider></md-divider>
+		</md-item>
+		{%- endfor %}
+	<md-list>
+</section>
 {%- endfor %}
 </ul>
 {% endblock %}

--- a/docs/templates/componentGroup.template.html
+++ b/docs/templates/componentGroup.template.html
@@ -9,7 +9,7 @@
 	{% for component in doc.children %}
 		<md-item>
 			<md-item-content layout-sm="column" layout-align-sm="space-around start">
-				<div class="md-tile-left" flex="15">
+				<div class="md-tile-content" flex="15">
 					{$ component | relativeLink(doc) $}
 				</div>
 				<div class="md-tile-content">

--- a/docs/templates/componentGroup.template.html
+++ b/docs/templates/componentGroup.template.html
@@ -9,7 +9,7 @@
 	{% for component in doc.children %}
 		<md-item>
 			<md-item-content layout-sm="column" layout-align-sm="space-around start">
-				<div class="md-tile-content" flex="15">
+				<div class="md-tile-content">
 					{$ component | relativeLink(doc) $}
 				</div>
 				<div class="md-tile-content">

--- a/docs/templates/ngModule.template.html
+++ b/docs/templates/ngModule.template.html
@@ -11,14 +11,14 @@
 {% if group.children.length %}
 <section>
 	<md-subheader>
-		{$ group.title $} -
-		{$ group | relativeLink(doc, '<md-button>List of ' + group.title + '</md-button>') $}
+		{$ group.title $}
+		{$ group | relativeLink(doc, '<md-button>View list of ' + group.title + '</md-button>') $}
 	</md-subheader>
 	<md-list>
 	{% for component in group.children %}
 		<md-item>
 			<md-item-content layout-sm="column" layout-align-sm="space-around start">
-				<div class="md-tile-left" flex="15">
+				<div class="md-tile-content">
 					{$ component | relativeLink(doc) $}
 				</div>
 				<div class="md-tile-content">

--- a/docs/templates/ngModule.template.html
+++ b/docs/templates/ngModule.template.html
@@ -1,26 +1,35 @@
 {% extends 'base.template.html' %}
 
 {% block body %}
-<div>
-  <h2>{$ doc.name $} Module</h2>
-
-  <div>
-  {$ doc.description | marked $}
-  </div>
-  {% include "partials/dependencies.template.html" %}
-</div>
+<h2>{$ doc.name $} Module</h2>
+<p>
+	{$ doc.description | marked $}
+</p>
+{% include "partials/dependencies.template.html" %}
 
 {% for groupName, group in doc.groups %}
 {% if group.children.length %}
-<material-divider></material-divider>
-<h3>{$ group | relativeLink(doc, group.title) $}</h3>
-<ul>
-{% for component in group.children %}
-<li>{$ component | relativeLink(doc) $}
-    {%- if component.description %} - {$ component.description $}{% endif -%}
-</li>
-{%- endfor %}
-</ul>
+<section>
+	<md-subheader>
+		{$ group.title $} -
+		{$ group | relativeLink(doc, '<md-button>List of ' + group.title + '</md-button>') $}
+	</md-subheader>
+	<md-list>
+	{% for component in group.children %}
+		<md-item>
+			<md-item-content layout-sm="column" layout-align-sm="space-around start">
+				<div class="md-tile-left" flex="15">
+					{$ component | relativeLink(doc) $}
+				</div>
+				<div class="md-tile-content">
+					{%- if component.description %} {$ component.description $}{% endif -%}
+				</div>
+			</md-item-content>
+			<md-divider></md-divider>
+		</md-item>
+		{%- endfor %}
+	<md-list>
+</section>
 {%- endif %}
 {%- endfor %}
 {% endblock %}

--- a/docs/templates/partials/dependencies.template.html
+++ b/docs/templates/partials/dependencies.template.html
@@ -1,12 +1,21 @@
 {% if doc.dependencies.length -%}
 
-<h3>Dependencies</h3>
-<ul>
-{%- for dependency in doc.dependencies %}
-  <li>
-  {$ dependency | relativeLink(doc) $}
-  </li>
-{%- endfor %}
-</ul>
-
+<section>
+	<md-subheader>Dependencies</md-subheader>
+	<md-list>
+	{%- for dependency in doc.dependencies %}
+		<md-item>
+			<md-item-content layout-sm="column" layout-align-sm="space-around start">
+				<div class="md-tile-left" flex="15">
+					{$ dependency | relativeLink(doc) $}
+				</div>
+				<div class="md-tile-content">
+					{$ dependency.description $}
+				</div>
+			</md-item-content>
+			<md-divider></md-divider>
+		</md-item>
+	{%- endfor %}
+	</md-list>
+</section>
 {%- endif %}

--- a/docs/templates/partials/dependencies.template.html
+++ b/docs/templates/partials/dependencies.template.html
@@ -6,11 +6,8 @@
 	{%- for dependency in doc.dependencies %}
 		<md-item>
 			<md-item-content layout-sm="column" layout-align-sm="space-around start">
-				<div class="md-tile-left" flex="15">
-					{$ dependency | relativeLink(doc) $}
-				</div>
 				<div class="md-tile-content">
-					{$ dependency.description $}
+					{$ dependency | relativeLink(doc) $}
 				</div>
 			</md-item-content>
 			<md-divider></md-divider>


### PR DESCRIPTION
This pull request 
- updates the generated markup to use the current elements and class names used in angular-material 0.8.3 (add a simple toolbar, make use of md-list)
- makes use of the minified bower dependencies
- removes the hammer.js script include which was not registered as an dependency and is not used anymore by angular-material
