### PR TITLE
Fixed clean task to correctly run default task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('assets', ['bower'], function() {
 });
 
 gulp.task('clean', function(done) {
-  del(['./build'], done);
+  return del(['./build'], done);
 });
 
 gulp.task('watch', ['default'], function() {


### PR DESCRIPTION
The default task uses runSequence which expects a promise to be returned and clean does not return one. Because of that, dgeni and assets tasks are not executed after the clean task.

Working like a charm now!